### PR TITLE
fix plugin_k210_parser bug

### DIFF
--- a/plugin_k210_parser.py
+++ b/plugin_k210_parser.py
@@ -32,10 +32,10 @@ def platform_parameters(parser):
                         help="Show conv2d weights range or not.")
     parser.add_argument("--input_type", type=str, default="",
                         help="input type: e.g. default, float, uint8, default means equal to inference type")
-    parser.add_argument("--input_std", type=float, default=0.000000,
-                        help="input std, default is 0.000000")
-    parser.add_argument("--input_mean", type=float, default=1.000000,
-                        help="input mean, default is 1.000000")
+    parser.add_argument("--input_std", type=float, default=1.000000,
+                        help="input std, default is 1.000000")
+    parser.add_argument("--input_mean", type=float, default=0.000000,
+                        help="input mean, default is 0.000000")
     parser.add_argument("--rt_ai_example", type=str, default="./platforms/plugin_k210",
                         help="Model & platform informations registered to RT-AK Lib, eg:stm32, k210.")
     parser.add_argument("--convert_report", type=str, default="./platforms/plugin_k210/convert_report.txt",


### PR DESCRIPTION
fix下面参数中的默认值

```python
    parser.add_argument("--input_std", type=float, default=1.000000,
                        help="input std, default is 1.000000")
    parser.add_argument("--input_mean", type=float, default=0.000000,
                        help="input mean, default is 0.000000")
```